### PR TITLE
Autocomplete places

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -507,3 +507,65 @@ document.getElementById("formulario-editar-evento").addEventListener("submit", a
     
     this.reset();
 });
+
+const api_KEY = "b89328181447414395b15d08230e986e";
+
+function activarAutocomplete(input) {
+  const suggestionBox = document.createElement("div");
+  suggestionBox.className = "autocomplete-items";
+
+  input.parentNode.style.position = "relative";
+  input.parentNode.appendChild(suggestionBox);
+
+  let debounceTimer;
+
+  input.addEventListener("input", () => {
+    const query = input.value.trim();
+    clearTimeout(debounceTimer);
+
+    if (query.length < 3) {
+      suggestionBox.style.display = "none";
+      return;
+    }
+
+    debounceTimer = setTimeout(async () => {
+      try {
+        const res = await fetch(
+          `https://api.geoapify.com/v1/geocode/autocomplete?text=${encodeURIComponent(query)}&apiKey=${api_KEY}`
+        );
+        const data = await res.json();
+
+        suggestionBox.innerHTML = "";
+
+        if (data.features.length > 0) {
+          data.features.forEach((item) => {
+            const suggestion = document.createElement("div");
+            suggestion.textContent = item.properties.formatted;
+            suggestion.className = "autocomplete-option";
+
+            suggestion.addEventListener("click", () => {
+              input.value = item.properties.formatted;
+              suggestionBox.style.display = "none";
+            });
+
+            suggestionBox.appendChild(suggestion);
+          });
+          suggestionBox.style.display = "block";
+        } else {
+          suggestionBox.style.display = "none";
+        }
+      } catch (error) {
+        console.error("Error en autocomplete:", error);
+      }
+    }, 300);
+  });
+
+  document.addEventListener("click", (e) => {
+    if (!suggestionBox.contains(e.target) && e.target !== input) {
+      suggestionBox.style.display = "none";
+    }
+  });
+}
+
+activarAutocomplete(document.getElementById("lugar-evento"));
+activarAutocomplete(document.getElementById("editar-lugar-evento"));

--- a/calendary.css
+++ b/calendary.css
@@ -509,3 +509,28 @@ body {
     border-color: #000;
     border-style: ridge;
 }
+
+.autocomplete-items {
+  position: absolute;
+  top: 130px;
+  left: 0;
+  width: 100%;
+  background: #fff;
+  border: 1px solid #ccc;
+  border-top: none;
+  z-index: 1000;
+  max-height: 200px;
+  overflow-y: auto;
+  display: none;
+  box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+}
+
+.autocomplete-option {
+  padding: 8px 12px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.autocomplete-option:hover {
+  background-color: #f0f0f0;
+}


### PR DESCRIPTION
Fixes #37
Se genera el auto completado para el apartado de lugar del evento funcionando para el opción de crear y editar

<img width="1470" height="956" alt="Captura de pantalla 2025-08-07 a la(s) 8 02 39 p m" src="https://github.com/user-attachments/assets/7fbe6ecf-7d44-4398-9fb6-fefd50e3b0ef" />
